### PR TITLE
OFI/BTL: accelerator - changes to support pt2pt

### DIFF
--- a/opal/mca/btl/ofi/btl_ofi_component.c
+++ b/opal/mca/btl/ofi/btl_ofi_component.c
@@ -458,6 +458,10 @@ static int mca_btl_ofi_init_device(struct fi_info *info)
         goto fail;
     }
 
+    if (info->caps & FI_HMEM) {
+        module->super.btl_flags |= MCA_BTL_FLAGS_ACCELERATOR_RDMA;
+    }
+
     /* If the user ask for two sided support, something bad is happening
      * to the MTL, so we will take maximum priority to supersede the MTL. */
     module->super.btl_exclusivity = MCA_BTL_EXCLUSIVITY_DEFAULT;

--- a/opal/mca/btl/ofi/btl_ofi_module.c
+++ b/opal/mca/btl/ofi/btl_ofi_module.c
@@ -248,6 +248,7 @@ int mca_btl_ofi_reg_mem(void *reg_data, void *base, size_t size,
     attr.access = access_flags;
     attr.offset = 0;
     attr.context = NULL;
+    attr.requested_key = (uint64_t)reg;
 
     if (OPAL_LIKELY(NULL != base)) {
         rc = opal_accelerator.check_addr(base, &dev_id, &flags);


### PR DESCRIPTION
through the OFI BTL when using accelerator memory

Signed-off-by: Howard Pritchard <howardp@lanl.gov>